### PR TITLE
アバターテーブルの修正

### DIFF
--- a/db/migrate/20241122045105_update_avatars_columns.rb
+++ b/db/migrate/20241122045105_update_avatars_columns.rb
@@ -1,0 +1,7 @@
+class UpdateAvatarsColumns < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :avatars, :body, :accessory_body
+    rename_column :avatars, :accessory, :accessory_head
+    add_column :avatars, :accessory_leg, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_11_061509) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_22_045105) do
   create_table "avatars", primary_key: "avatar_id", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "body", default: 0
-    t.integer "accessory", default: 0
+    t.integer "accessory_body", default: 0
+    t.integer "accessory_head", default: 0
     t.boolean "logged_in", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "comment", default: ""
+    t.integer "accessory_leg", default: 0
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
アクセサリー頭、アクセサリー体、アクセサリー足カラムというようにした。
bodyに関しては、学籍番号（student_id）カラムで管理するため、削除した