### PR TITLE
広場にログインログアウト、アクセサリ更新、コメント更新のAPIの修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,8 @@ Rails.application.routes.draw do
   get '/show', to: 'sessions#me'
 
   #アバターの情報更新
-  patch '/users/:id/avatar/accessory', to: 'avatars#update_accessory'
-  patch '/users/:id/avatar/comment', to: 'avatars#update_comment'
-  patch '/users/:id/avatar/login', to: 'avatars#avatar_login'
-  patch '/users/:id/avatar/logout', to: 'avatars#avatar_logout'
-
-  #get "up" => "rails/health#show", as: :rails_health_check
+  patch '/avatar/login', to: 'avatars#avatar_login'
+  patch '/avatar/logout', to: 'avatars#avatar_logout'
+  patch '/avatar/accessory/update', to: 'avatars#update_accessory_me'
+  patch '/avatar/comment/update', to: 'avatars#update_comment_me'
 end


### PR DESCRIPTION
変更前 ：idをURIに含め、それに対して更新していた
変更後：APIが呼ばれたと同時に自分自身を特定し、それに対して更新処理を行う

のに修正した